### PR TITLE
Added developer assistant and made various enhancements

### DIFF
--- a/Classes/JSONAPI.h
+++ b/Classes/JSONAPI.h
@@ -12,6 +12,7 @@
 #import "JSONAPIResourceFormatter.h"
 #import "JSONAPIResourceLinker.h"
 #import "JSONAPIResourceModeler.h"
+#import "JSONAPIDeveloperAssistant.h"
 
 @interface JSONAPI : NSObject
 

--- a/Classes/JSONAPI.m
+++ b/Classes/JSONAPI.m
@@ -45,7 +45,7 @@
 - (void)inflateWithString:(NSString*)string {
     id json = [NSJSONSerialization JSONObjectWithData:[string dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
     
-    if ([json isKindOfClass:[NSDictionary class]] == YES) {
+    if ([json isKindOfClass:[NSDictionary class]]) {
         [self inflateWithDictionary:json];
     } else {
         _error = [NSError errorWithDomain:@"Could not parse JSON" code:0 userInfo:nil];
@@ -70,13 +70,13 @@
 }
 
 - (NSArray*)resourcesForKey:(NSString*)key {
-    if ([key isEqualToString:@"meta"] == YES || [key isEqualToString:@"linked"] == YES) {
+    if ([key isEqualToString:@"meta"] || [key isEqualToString:@"linked"]) {
         return nil;
     }
     
     NSArray *rawResources = [_dictionary objectForKey:key];
     NSArray *resources = nil;
-    if ([rawResources isKindOfClass:[NSArray class]] == YES) {
+    if ([rawResources isKindOfClass:[NSArray class]]) {
         Class c = [JSONAPIResourceModeler resourceForLinkedType:[JSONAPIResourceLinker linkedType:key]];
         resources = [JSONAPIResource jsonAPIResources:rawResources withLinked:self.linked withClass:c];
     }
@@ -99,7 +99,7 @@
     // Sets linked
     NSMutableDictionary *creatingLinked = [NSMutableDictionary dictionary];
     NSDictionary *rawLinked = [dictionary objectForKey:@"linked"];
-    if ([rawLinked isKindOfClass:[NSDictionary class]] == YES) {
+    if ([rawLinked isKindOfClass:[NSDictionary class]]) {
         
         NSMutableArray *linkedToLinkWithLinked = [NSMutableArray array];
         
@@ -107,7 +107,7 @@
         for (NSString *key in rawLinked.allKeys) {
             NSArray *value = [rawLinked objectForKey:key];
             
-            if ([value isKindOfClass:[NSArray class]] == YES) {
+            if ([value isKindOfClass:[NSArray class]]) {
                 NSMutableDictionary *resources = [NSMutableDictionary dictionary];
                 for (NSDictionary *resourceDictionary in value) {
                     Class c = [JSONAPIResourceModeler resourceForLinkedType:[JSONAPIResourceLinker linkedType:key]];

--- a/Classes/JSONAPIDeveloperAssistant.h
+++ b/Classes/JSONAPIDeveloperAssistant.h
@@ -1,0 +1,32 @@
+//
+//  JSONAPIDeveloperAssistant.h
+//  JSONAPI
+//
+//  Created by Brennan Stehling on 7/10/14.
+//  Copyright (c) 2014 Josh Holtz. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface JSONAPIDeveloperAssistant : NSObject
+
++ (JSONAPIDeveloperAssistant *)defaultDeveloperAssistant;
++ (void)resetDefaultDeveloperAssistant;
+
++ (void)setDevelopmentModeEnabled:(BOOL)enabled;
++ (BOOL)isDevelopmentModeEnabled;
+
+// all json keys are added to mapping store
+- (void)addJsonKey:(NSString *)jsonKey withPropertyName:(NSString *)propertyName forClassName:(NSString *)className;
+
+// json keys which were mapped to properties
+- (void)addMappedJsonKey:(NSString *)jsonKey withPropertyName:(NSString *)propertyName forClassName:(NSString *)className;
+// json keys which were not mapped to properties
+- (void)addUnmappedJsonKey:(NSString *)jsonKey withPropertyName:(NSString *)propertyName forClassName:(NSString *)className;
+
+- (NSArray *)mappedKeysForClassName:(NSString *)className;
+- (NSArray *)unmappedKeysForClassName:(NSString *)className;
+
+- (void)logMappedModels;
+
+@end

--- a/Classes/JSONAPIDeveloperAssistant.m
+++ b/Classes/JSONAPIDeveloperAssistant.m
@@ -1,0 +1,192 @@
+//
+//  JSONAPIDeveloperAssistant.m
+//  JSONAPI
+//
+//  Created by Brennan Stehling on 7/10/14.
+//  Copyright (c) 2014 Josh Holtz. All rights reserved.
+//
+
+// Notes:
+// Developer Assistant is used when Development Mode is enabled.
+// Models which are mapped are recored by the Developer Assistant
+// with each key that is mapped and not mapped. The purpose of the
+// DA will be to help the developer discover which JSON values are
+// not being mapped and to facilitate with adding those mappings
+// to the models.
+//
+// The mapping will be the following:
+// Class Name -> mapped json keys
+//            -> unmapped json keys
+
+#import "JSONAPIDeveloperAssistant.h"
+
+#define kModelsKey @"models"
+#define kAllKey @"all"
+#define kMappedKey @"mapped"
+#define kUnmappedKey @"unmapped"
+
+#pragma mark - Class Extension
+#pragma mark -
+
+@interface JSONAPIDeveloperAssistant ()
+
+@property (strong, nonatomic) NSMutableDictionary *mappedModels;
+
+@end
+
+@implementation JSONAPIDeveloperAssistant {
+    BOOL _isPruned;
+}
+
+static BOOL _isDevelopmentModeEnabled = FALSE;
+
+static JSONAPIDeveloperAssistant *_defaultDeveloperAssistant;
+
+#pragma mark - Public
+#pragma mark -
+
++ (JSONAPIDeveloperAssistant *)defaultDeveloperAssistant {
+    if (!_defaultDeveloperAssistant) {
+        _defaultDeveloperAssistant = [[JSONAPIDeveloperAssistant alloc] init];
+        NSDictionary *mappedModels = @{ kModelsKey : @{}.mutableCopy };
+        _defaultDeveloperAssistant.mappedModels = mappedModels.mutableCopy;
+        
+    }
+    
+    return _defaultDeveloperAssistant;
+}
+
++ (void)resetDefaultDeveloperAssistant {
+    _defaultDeveloperAssistant = nil;
+}
+
++ (void)setDevelopmentModeEnabled:(BOOL)enabled {
+    _isDevelopmentModeEnabled = enabled;
+}
+
++ (BOOL)isDevelopmentModeEnabled {
+    return _isDevelopmentModeEnabled;
+}
+
+- (void)addJsonKey:(NSString *)jsonKey withPropertyName:(NSString *)propertyName forClassName:(NSString *)className {
+    [self addJsonKey:jsonKey withPropertyName:propertyName forClassName:className inGroup:kAllKey];
+}
+
+- (void)addMappedJsonKey:(NSString *)jsonKey withPropertyName:(NSString *)propertyName forClassName:(NSString *)className {
+    [self addJsonKey:jsonKey withPropertyName:propertyName forClassName:className inGroup:kMappedKey];
+}
+
+- (void)addUnmappedJsonKey:(NSString *)jsonKey withPropertyName:(NSString *)propertyName forClassName:(NSString *)className {
+    [self addJsonKey:jsonKey withPropertyName:propertyName forClassName:className inGroup:kUnmappedKey];
+}
+
+- (void)logMappedModels {
+    [self prune];
+    
+    NSLog(@"#### Mapped Models ####");
+    NSLog(@"%@", self.mappedModels[kModelsKey]);
+}
+
+- (NSArray *)mappedKeysForClassName:(NSString *)className {
+    [self prune];
+    
+    NSDictionary *mapped = self.mappedModels[kModelsKey][className][kMappedKey];
+    if (mapped) {
+        return mapped.allKeys;
+    }
+    else {
+        return nil;
+    }
+}
+
+- (NSArray *)unmappedKeysForClassName:(NSString *)className {
+    [self prune];
+    
+    NSDictionary *unmapped = self.mappedModels[kModelsKey][className][kUnmappedKey];
+    if (unmapped) {
+        return unmapped.allKeys;
+    }
+    else {
+        return nil;
+    }
+}
+
+#pragma mark - Private
+#pragma mark -
+
+- (void)addJsonKey:(NSString *)jsonKey withPropertyName:(NSString *)propertyName forClassName:(NSString *)className inGroup:(NSString *)groupName {
+    if (!jsonKey.length || !propertyName.length || !className.length || !groupName.length) {
+        NSLog(@"WARNING: Attempted to add invalid values to Developer Assistant mapping");
+        return;
+    }
+
+    // do not map the standard json keys
+    if ([@"id" isEqualToString:jsonKey] || [@"href" isEqualToString:jsonKey] || [@"links" isEqualToString:jsonKey] || [@"meta" isEqualToString:jsonKey]) {
+        return;
+    }
+    
+    NSMutableDictionary *models = self.mappedModels[kModelsKey];
+    
+    NSMutableDictionary *model = nil;
+    if (!models[className]) {
+        model = @{}.mutableCopy;
+        models[className] = model;
+    }
+    else {
+        model = models[className];
+    }
+    
+    NSMutableDictionary *group = nil;
+    if (!model[groupName]) {
+        group = @{}.mutableCopy;
+        model[groupName] = group;
+    }
+    else {
+        group = model[groupName];
+    }
+    
+    if (!group[jsonKey]) {
+        _isPruned = FALSE;
+        group[jsonKey] = propertyName;
+    }
+}
+
+- (void)prune {
+    // 1) remove all items from all which have the "links." prefix
+    // 2) add items from all to unmapped if not in mapped
+    // 3) remove items from unmapped if they are in mapped
+    
+    NSMutableDictionary *models = self.mappedModels[kModelsKey];
+    for (NSString *className in models.allKeys) {
+        NSMutableDictionary *model = models[className];
+        
+        NSMutableDictionary *all = model[kAllKey];
+        NSMutableDictionary *mapped = model[kMappedKey];
+        NSMutableDictionary *unmapped = model[kUnmappedKey];
+        
+        NSMutableArray *itemsToRemove = @[].mutableCopy;
+        for (NSString *allKey in all.allKeys) {
+            if ([allKey hasPrefix:@"links."]) {
+                [itemsToRemove addObject:allKey];
+            }
+            else {
+                if (!mapped[allKey]) {
+                    unmapped[allKey] = all[allKey];
+                }
+            }
+        }
+        [all removeObjectsForKeys:itemsToRemove];
+        [itemsToRemove removeAllObjects];
+        
+        for (NSString *unmappedKey in unmapped.allKeys) {
+            if (mapped[unmappedKey]) {
+                [itemsToRemove addObject:unmappedKey];
+            }
+        }
+        [unmapped removeObjectsForKeys:itemsToRemove];
+    }
+    
+    _isPruned = TRUE;
+}
+
+@end

--- a/Classes/JSONAPIResource.h
+++ b/Classes/JSONAPIResource.h
@@ -14,6 +14,8 @@
 @property (nonatomic, strong) NSString *href;
 @property (nonatomic, strong) NSDictionary *links;
 
+@property (nonatomic, readonly) NSDictionary *mapKeysToProperties;
+
 + (NSArray*)jsonAPIResources:(NSArray*)array withLinked:(NSDictionary*)linked;
 + (NSArray*)jsonAPIResources:(NSArray*)array withLinked:(NSDictionary*)linked withClass:(Class)resourceObjectClass;
 
@@ -27,6 +29,6 @@
 
 - (void)linkLinks:(NSDictionary*)linked;
 
-- (NSDictionary *)mapKeysToProperties;
+- (BOOL)isEqualToJSONAPIResource:(JSONAPIResource *)jsonApiResource;
 
 @end

--- a/Classes/JSONAPIResource.m
+++ b/Classes/JSONAPIResource.m
@@ -10,6 +10,7 @@
 
 #import "JSONAPIResourceFormatter.h"
 #import "JSONAPIResourceLinker.h"
+#import "JSONAPIDeveloperAssistant.h"
 
 #import <objc/runtime.h>
 #import <objc/message.h>
@@ -87,56 +88,71 @@
 }
 
 - (NSDictionary *)mapKeysToProperties {
-    return [[NSDictionary alloc] init];
+    return @{};
 }
 
-- (void)setWithDictionary:(NSDictionary*)dict {
-    self.__dictionary = dict;
+- (void)setWithDictionary:(NSDictionary*)jsonDict {
+    self.__dictionary = jsonDict;
     
     // Loops through all keys to map to propertiess
-    NSDictionary *userMap = [self mapKeysToProperties];
+    NSMutableDictionary *map = self.mapKeysToProperties.mutableCopy;
     
-    NSMutableDictionary *map = [NSMutableDictionary dictionaryWithDictionary:userMap];
     [map addEntriesFromDictionary:@{
-                                         @"id" : @"ID",
-                                         @"href" : @"href",
-                                         @"links" : @"links"
-                                         }];
+                                    @"id" : @"ID",
+                                    @"href" : @"href",
+                                    @"links" : @"links"
+                                    }];
     
-    for (NSString *key in [map allKeys]) {
+    BOOL enabled = [JSONAPIDeveloperAssistant isDevelopmentModeEnabled];
+    JSONAPIDeveloperAssistant *da = enabled ? [JSONAPIDeveloperAssistant defaultDeveloperAssistant] : nil;
+    NSString *className = enabled ? NSStringFromClass([self class]) : nil;
+    
+    if (enabled) {
+        for (NSString *jsonKey in jsonDict.allKeys) {
+            [da addUnmappedJsonKey:jsonKey withPropertyName:@"<null>" forClassName:className];
+        }
+    }
+    
+    for (NSString *jsonKey in map.allKeys) {
+        
+        NSString *propertyName = map[jsonKey];
+        [da addJsonKey:jsonKey withPropertyName:propertyName forClassName:className];
         
         // Checks if the key to map is in the dictionary to map
-        if ([dict objectForKey:key] != nil && [dict objectForKey:key] != [NSNull null]) {
+        if (jsonDict[jsonKey] != nil && jsonDict[jsonKey] != [NSNull null]) {
             
-            NSString *property = [map objectForKey:key];
-            
-            NSRange inflateRange = [property rangeOfString:@"."];
-            NSRange formatRange = [property rangeOfString:@":"];
+            NSRange inflateRange = [propertyName rangeOfString:@"."];
+            NSRange formatRange = [propertyName rangeOfString:@":"];
             
             @try {
                 if (inflateRange.location != NSNotFound) {
-
-                } else if (formatRange.location != NSNotFound) {
-                    NSString *formatFunction = [property substringToIndex:formatRange.location];
-                    property = [property substringFromIndex:(formatRange.location+1)];
-                    
-                    [self setValue:[JSONAPIResourceFormatter performFormatBlock:[dict objectForKey:key] withName:formatFunction] forKey:property ];
-                } else {
-                    [self setValue:[dict objectForKey:key] forKey:property ];
+                    // do not map properties with dot syntax (links)
+                }
+                else if (formatRange.location != NSNotFound) {
+                    NSString *formatFunction = [propertyName substringToIndex:formatRange.location];
+                    propertyName = [propertyName substringFromIndex:(formatRange.location+1)];
+                    id parsedValue = [JSONAPIResourceFormatter performFormatBlock:jsonDict[jsonKey] withName:formatFunction];
+                    [self setValue:parsedValue forKey:propertyName];
+                    [da addMappedJsonKey:jsonKey withPropertyName:propertyName forClassName:className];
+                }
+                else {
+                    [self setValue:jsonDict[jsonKey] forKey:propertyName];
+                    [da addMappedJsonKey:jsonKey withPropertyName:propertyName forClassName:className];
                 }
             }
             @catch (NSException *exception) {
                 NSLog(@"JSONAPIResource Warning - %@", [exception description]);
             }
-            
-        } else {
-            
         }
-        
     }
 }
 
 - (void)linkLinks:(NSDictionary*)linked {
+    
+    BOOL enabled = [JSONAPIDeveloperAssistant isDevelopmentModeEnabled];
+    JSONAPIDeveloperAssistant *da = enabled ? [JSONAPIDeveloperAssistant defaultDeveloperAssistant] : nil;
+    NSString *className = enabled ? NSStringFromClass([self class]) : nil;
+    
     // Loops through links of resources
     for (NSString *linkTypeUnmapped in self.links.allKeys) {
         
@@ -146,20 +162,20 @@
         }
         
         // Gets linked objects for the resource
-        id linksTo = [self.links objectForKey:linkTypeUnmapped];
-        if ([linksTo isKindOfClass:[NSNumber class]] == YES || [linksTo isKindOfClass:[NSString class]] == YES) {
+        id linksTo = self.links[linkTypeUnmapped];
+        if ([linksTo isKindOfClass:[NSNumber class]] || [linksTo isKindOfClass:[NSString class]]) {
             
-            JSONAPIResource *linkedResource = [[linked objectForKey:linkType] objectForKey:linksTo];
+            JSONAPIResource *linkedResource = linked[linkType][linksTo];
             
             if (linkedResource != nil) {
                 [self.__resourceLinks setObject:linkedResource forKey:linkTypeUnmapped];
             }
             
-        } else if ([linksTo isKindOfClass:[NSArray class]] == YES) {
+        } else if ([linksTo isKindOfClass:[NSArray class]]) {
             NSMutableArray *linkedResources = [NSMutableArray array];
             [self.__resourceLinks setObject:linkedResources forKey:linkTypeUnmapped];
             for (id linkedId in linksTo) {
-                JSONAPIResource *linkedResource = [[linked objectForKey:linkType] objectForKey:linkedId];
+                JSONAPIResource *linkedResource = linked[linkType][linkedId];
                 if (linkedResource != nil) {
                     [linkedResources addObject:linkedResource];
                 }
@@ -169,17 +185,22 @@
     }
     
     // Link links for mapped key to properties
-    for (NSString *key in [self mapKeysToProperties]) {
-        if ([key hasPrefix:@"links."] == YES) {
+    
+    NSDictionary *map = self.mapKeysToProperties;
+    
+    for (NSString *jsonKey in map) {
+        if ([jsonKey hasPrefix:@"links."]) {
             
-            NSString *propertyName = [[self mapKeysToProperties] objectForKey:key];
-            NSString *linkedResource = [key stringByReplacingOccurrencesOfString:@"links." withString:@""];
+            NSString *propertyName = map[jsonKey];
+            NSString *linkedResource = [jsonKey stringByReplacingOccurrencesOfString:@"links." withString:@""];
+            
+            [da addJsonKey:jsonKey withPropertyName:propertyName forClassName:className];
             
             id resource = [self linkedResourceForKey:linkedResource];
             if (resource != nil) {
-                
                 @try {
                     [self setValue:resource forKey:propertyName];
+                    [da addMappedJsonKey:linkedResource withPropertyName:propertyName forClassName:className];
                 }
                 @catch (NSException *exception) {
                     NSLog(@"JSONAPIResource Warning - %@", [exception description]);
@@ -187,6 +208,39 @@
             }
             
         }
+    }
+}
+
+#pragma mark - NSObject
+
+- (BOOL)isEqual:(id)other {
+    if (other == self) {
+        return YES;
+    }
+    else if ([other isKindOfClass:[JSONAPIResource class]]) {
+        JSONAPIResource *otherResource = (JSONAPIResource *)other;
+        return [self isEqualToJSONAPIResource:otherResource];
+    }
+    else {
+        return FALSE;
+    }
+}
+
+- (BOOL)isEqualToJSONAPIResource:(JSONAPIResource *)jsonApiResource {
+    if (jsonApiResource) {
+        return [self.ID isEqual:jsonApiResource.ID];
+    }
+    else {
+        return FALSE;
+    }
+}
+
+- (NSUInteger)hash {
+    if (self.ID && [self.ID respondsToSelector:@selector(hash)]) {
+        return [self.ID hash];
+    }
+    else {
+        return [super hash];
     }
 }
 
@@ -203,7 +257,7 @@
         // Link links for mapped key to properties
         for (NSString *key in [copy __resourceLinks]) {
             @try {
-                [copy setValue:[[copy __resourceLinks] objectForKey:key] forKey:key];
+                [copy setValue:[copy __resourceLinks][key] forKey:key];
             }
             @catch (NSException *exception) {
                 NSLog(@"JSONAPIResource Warning - %@", [exception description]);
@@ -217,8 +271,7 @@
 
 #pragma mark - NSCoding
 
-- (NSArray *)propertyKeys
-{
+- (NSArray *)propertyKeys {
     NSMutableArray *array = [NSMutableArray array];
     Class class = [self class];
     while (class != [NSObject class])
@@ -266,8 +319,7 @@
     return array;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder
-{
+- (id)initWithCoder:(NSCoder *)aDecoder {
     if ((self = [self init]))
     {
         for (NSString *key in [self propertyKeys])
@@ -279,8 +331,7 @@
     return self;
 }
 
-- (void)encodeWithCoder:(NSCoder *)aCoder
-{
+- (void)encodeWithCoder:(NSCoder *)aCoder {
     for (NSString *key in [self propertyKeys])
     {
         id value = [self valueForKey:key];

--- a/Project/JSONAPI.xcodeproj/project.pbxproj
+++ b/Project/JSONAPI.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		03A055F71868E08A004807F0 /* JSONAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 03A055F41868E08A004807F0 /* JSONAPI.m */; };
 		03A055F81868E08A004807F0 /* JSONAPI.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 03A055F51868E08A004807F0 /* JSONAPI.podspec */; };
 		03A9ED58196DEF9B00E61E2E /* JSONAPIResourceFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03A9ED57196DEF9B00E61E2E /* JSONAPIResourceFormatter.m */; };
+		26733EE1196F5F8C0058384A /* JSONAPIDeveloperAssistant.m in Sources */ = {isa = PBXBuildFile; fileRef = 26733EE0196F5F8C0058384A /* JSONAPIDeveloperAssistant.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,8 @@
 		03A055F51868E08A004807F0 /* JSONAPI.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = JSONAPI.podspec; path = ../JSONAPI.podspec; sourceTree = "<group>"; };
 		03A9ED56196DEF9B00E61E2E /* JSONAPIResourceFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSONAPIResourceFormatter.h; sourceTree = "<group>"; };
 		03A9ED57196DEF9B00E61E2E /* JSONAPIResourceFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSONAPIResourceFormatter.m; sourceTree = "<group>"; };
+		26733EDF196F5F8C0058384A /* JSONAPIDeveloperAssistant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSONAPIDeveloperAssistant.h; sourceTree = "<group>"; };
+		26733EE0196F5F8C0058384A /* JSONAPIDeveloperAssistant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSONAPIDeveloperAssistant.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,6 +213,8 @@
 				0386643C186A0DAD00985CEC /* JSONAPIResourceLinker.m */,
 				0386644C186A8DA000985CEC /* JSONAPIResourceModeler.h */,
 				0386644D186A8DA000985CEC /* JSONAPIResourceModeler.m */,
+				26733EDF196F5F8C0058384A /* JSONAPIDeveloperAssistant.h */,
+				26733EE0196F5F8C0058384A /* JSONAPIDeveloperAssistant.m */,
 			);
 			name = Classes;
 			path = ../Classes;
@@ -259,7 +264,7 @@
 		03A055AF1868E038004807F0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Josh Holtz";
 				TargetAttributes = {
 					03A055D71868E038004807F0 = {
@@ -324,6 +329,7 @@
 				03A9ED58196DEF9B00E61E2E /* JSONAPIResourceFormatter.m in Sources */,
 				03A055CB1868E038004807F0 /* AppDelegate.m in Sources */,
 				0386644E186A8DA000985CEC /* JSONAPIResourceModeler.m in Sources */,
+				26733EE1196F5F8C0058384A /* JSONAPIDeveloperAssistant.m in Sources */,
 				03A055C71868E038004807F0 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -378,7 +384,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -417,7 +422,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -475,7 +479,6 @@
 		03A055ED1868E038004807F0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/JSONAPI.app/JSONAPI";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -498,7 +501,6 @@
 		03A055EE1868E038004807F0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/JSONAPI.app/JSONAPI";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",

--- a/Project/JSONAPITests/JSONAPITests.m
+++ b/Project/JSONAPITests/JSONAPITests.m
@@ -20,8 +20,7 @@
 
 @implementation JSONAPITests
 
-- (void)setUp
-{
+- (void)setUp {
     [super setUp];
 
     [JSONAPIResourceLinker link:@"author" toLinkedType:@"authors"];
@@ -37,16 +36,14 @@
     
 }
 
-- (void)tearDown
-{
+- (void)tearDown {
     [JSONAPIResourceLinker unlinkAll];
     [JSONAPIResourceModeler unmodelAll];
     
     [super tearDown];
 }
 
-- (void)testMeta
-{
+- (void)testMeta {
     NSDictionary *meta = @{ @"page_number" : @1, @"number_of_pages" : @5};
     NSDictionary *linked = @{ @"authors" : @[ @{ @"id" : @9, @"name" : @"Josh" } ] };
     NSDictionary *json = @{ @"meta" : meta, @"linked" : linked, @"posts" : @[ @{ @"id" : @1, @"name" : @"Josh is awesome", @"links" : @{ @"author" : @9 } } ] };
@@ -56,8 +53,7 @@
     
 }
 
-- (void)testBadMeta
-{
+- (void)testBadMeta {
     NSArray *meta = @[ @{ @"page_number" : @1, @"number_of_pages" : @5} ];
     NSDictionary *linked = @{ @"authors" : @[ @{ @"id" : @9, @"name" : @"Josh" } ] };
     NSDictionary *json = @{ @"meta" : meta, @"linked" : linked, @"posts" : @[ @{ @"id" : @1, @"name" : @"Josh is awesome", @"links" : @{ @"author" : @9 } } ] };
@@ -67,14 +63,13 @@
     
 }
 
-- (void)testLinkedCount
-{
+- (void)testLinkedCount {
     NSDictionary *meta = @{ @"page_number" : @1, @"number_of_pages" : @5};
     NSDictionary *linked = @{ @"authors" : @[ @{ @"id" : @9, @"name" : @"Josh" } ] };
     NSDictionary *json = @{ @"meta" : meta, @"linked" : linked, @"posts" : @[ @{ @"id" : @1, @"name" : @"Josh is awesome", @"links" : @{ @"author" : @9 } } ] };
     
     JSONAPI *jsonAPI = [[JSONAPI alloc] initWithDictionary:json];
-    XCTAssert(linked.count == jsonAPI.linked.count, @"Linked count does not equal %d", linked.count);
+    XCTAssert(linked.count == jsonAPI.linked.count, @"Linked count does not equal %lu", (unsigned long)linked.count);
     
 }
 
@@ -90,16 +85,14 @@
     XCTAssertEqualObjects([linkedAuthor9 objectForKey:@"name"], [linkedAuthorResource objectForKey:@"name"] , @"Author resource name does not equal %@", [linkedAuthor9 objectForKey:@"name"]);
 }
 
-- (void)testBadLinked
-{
+- (void)testBadLinked {
     NSDictionary *meta = @{ @"page_number" : @1, @"number_of_pages" : @5};
     NSArray *linked = @[ @{ @"authors" : @[ @{ @"id" : @9, @"name" : @"Josh" } ] } ];
     NSDictionary *json = @{ @"meta" : meta, @"linked" : linked, @"posts" : @[ @{ @"id" : @1, @"name" : @"Josh is awesome", @"links" : @{ @"author" : @9 } } ] };
     
     JSONAPI *jsonAPI = [[JSONAPI alloc] initWithDictionary:json];
-    NSLog(@"%d HRM %d", jsonAPI.linked.count, 0);
+    NSLog(@"%lu HRM %d", (unsigned long)jsonAPI.linked.count, 0);
     XCTAssert(jsonAPI.linked.count == 0, @"Linked is not 0");
-    
 }
 
 - (void)testResourcesCount {
@@ -111,7 +104,7 @@
     NSDictionary *json = @{ @"meta" : meta, @"linked" : linked, @"posts" : posts };
     
     JSONAPI *jsonAPI = [[JSONAPI alloc] initWithDictionary:json];
-    XCTAssert(posts.count == [jsonAPI resourcesForKey:@"posts"].count, @"Posts count does not equal %d", posts.count);
+    XCTAssert(posts.count == [jsonAPI resourcesForKey:@"posts"].count, @"Posts count does not equal %lu", (unsigned long)posts.count);
 }
 
 - (void)testResourcesObject {
@@ -161,14 +154,14 @@
     NSArray *linkedAuthorsResources = [resource linkedResourceForKey:@"authors"];
     JSONAPIResource *linkedAuthorResource9, *linkedAuthorResource11;
     for (JSONAPIResource *linkedAuthorResource in linkedAuthorsResources) {
-        if ([linkedAuthorResource.ID isEqualToString:[linkedAuthor9 objectForKey:@"id"]] == YES) {
+        if ([linkedAuthorResource.ID isEqualToString:[linkedAuthor9 objectForKey:@"id"]]) {
             linkedAuthorResource9 = linkedAuthorResource;
-        } else if ([linkedAuthorResource.ID isEqualToString:[linkedAuthor11 objectForKey:@"id"]] == YES) {
+        } else if ([linkedAuthorResource.ID isEqualToString:[linkedAuthor11 objectForKey:@"id"]]) {
             linkedAuthorResource11 = linkedAuthorResource;
         }
     }
 
-    XCTAssert(linkedAuthorsResources.count == linkedAuthors.count, @"Linked author resource count is not %d", linkedAuthors.count);
+    XCTAssert(linkedAuthorsResources.count == linkedAuthors.count, @"Linked author resource count is not %lu", (unsigned long)linkedAuthors.count);
     
     XCTAssertEqualObjects([linkedAuthorResource9 objectForKey:@"name"], [linkedAuthor9 objectForKey:@"name"], @"Linked author's 9 name is not equal to %@", [linkedAuthor9 objectForKey:@"name"]);
     
@@ -213,14 +206,14 @@
     NSArray *linkedAuthorsResources = [resource linkedResourceForKey:@"authors"];
     JSONAPIResource *linkedAuthorResource9, *linkedAuthorResource11;
     for (JSONAPIResource *linkedAuthorResource in linkedAuthorsResources) {
-        if ([linkedAuthorResource.ID isEqualToNumber:[linkedAuthor9 objectForKey:@"id"]] == YES) {
+        if ([linkedAuthorResource.ID isEqualToNumber:[linkedAuthor9 objectForKey:@"id"]]) {
             linkedAuthorResource9 = linkedAuthorResource;
-        } else if ([linkedAuthorResource.ID isEqualToNumber:[linkedAuthor11 objectForKey:@"id"]] == YES) {
+        } else if ([linkedAuthorResource.ID isEqualToNumber:[linkedAuthor11 objectForKey:@"id"]]) {
             linkedAuthorResource11 = linkedAuthorResource;
         }
     }
     
-    XCTAssert(linkedAuthorsResources.count == linkedAuthors.count, @"Linked author resource count is not %d", linkedAuthors.count);
+    XCTAssert(linkedAuthorsResources.count == linkedAuthors.count, @"Linked author resource count is not %lu", (unsigned long)linkedAuthors.count);
     
     XCTAssertEqualObjects([linkedAuthorResource9 objectForKey:@"name"], [linkedAuthor9 objectForKey:@"name"], @"Linked author's 9 name is not equal to %@", [linkedAuthor9 objectForKey:@"name"]);
     XCTAssertEqualObjects([linkedAuthorResource9 objectForKey:@"name"], [linkedAuthor9 objectForKey:@"name"], @"Linked author's 9 name is not equal to %@", [linkedAuthor9 objectForKey:@"name"]);
@@ -328,6 +321,7 @@
     
     PostResource *copyPostResource = [postResource copy];
     
+    XCTAssertTrue([copyPostResource isEqual:postResource], @"Copy post must be equal to original");
     XCTAssertNotEqual(copyPostResource, postResource, @"Copy post is equal to original");
     XCTAssertNotNil(copyPostResource.name, @"Copy post name is nil");
     XCTAssertEqualObjects(copyPostResource.name, postResource.name, @"Copy post name is not equal to %@", postResource.name);
@@ -383,6 +377,63 @@
     XCTAssertNotEqual(postResource, copyPostResource, @"Post is not equal to copy");
     XCTAssertNotNil(postResource.date, @"Post date is not nil");
     XCTAssertEqualObjects(postResource.date, date, @"Post date is not equal to %@", date);
+}
+
+- (void)testEquality {
+    PostResource *postResource = [[PostResource alloc] init];
+    PostResource *otherPostResource = [[PostResource alloc] init];
+    
+    postResource.ID = @99;
+    otherPostResource.ID = @99;
+    
+    XCTAssertTrue([postResource isEqual:otherPostResource], @"Post must be equal to other post");
+}
+
+- (void)testInequality {
+    PostResource *postResource = [[PostResource alloc] init];
+    PostResource *otherPostResource = [[PostResource alloc] init];
+    
+    postResource.ID = @99;
+    otherPostResource.ID = @101;
+    
+    XCTAssertFalse([postResource isEqual:otherPostResource], @"Post must not be equal to other post");
+}
+
+- (void)testUnmapped {
+    [JSONAPIDeveloperAssistant setDevelopmentModeEnabled:TRUE];
+    [JSONAPIDeveloperAssistant resetDefaultDeveloperAssistant];
+
+    // Create date for testing
+    NSString *dateToTestWith = @"2013-10-14T05:34:32+600";
+    
+    NSDictionary *meta = @{ @"page_number" : @1, @"number_of_pages" : @5};
+    NSDictionary *linkedAuthor9 = @{ @"id" : @9, @"name" : @"Josh" };
+    NSDictionary *linkedAuthor11 = @{ @"id" : @11, @"name" : @"Bandit" };
+    NSArray *linkedAuthors = @[ linkedAuthor9, linkedAuthor11 ];
+    NSDictionary *linked = @{ @"authors" : linkedAuthors };
+    NSDictionary *post = @{ @"id" : @1, @"name" : @"Josh is awesome", @"links" : @{ @"author" : @9 }, @"date" : dateToTestWith, @"tags" : @[@"movies", @"action"], @"category" : @"entertainment" };
+    NSArray *posts = @[ post ];
+    NSDictionary *json = @{ @"meta" : meta, @"linked" : linked, @"posts" : posts, @"comments" : @[@"none"] };
+    
+    JSONAPI *jsonAPI = [[JSONAPI alloc] initWithDictionary:json];
+    PostResource *postResource __unused = [jsonAPI resourceForKey:@"posts"];
+    
+    JSONAPIDeveloperAssistant *da = [JSONAPIDeveloperAssistant defaultDeveloperAssistant];
+    
+    NSString *className = NSStringFromClass([PostResource class]);
+    NSArray *mapped = [da mappedKeysForClassName:className];
+    NSArray *unmapped = [da unmappedKeysForClassName:className];
+    
+    [da logMappedModels];
+    [JSONAPIDeveloperAssistant resetDefaultDeveloperAssistant];
+    
+    // The extra keys which will not be mapped are tags and category in the post resource
+    
+    XCTAssertTrue([mapped containsObject:@"name"], @"The 'name' key should be mapped");
+    XCTAssertTrue([mapped containsObject:@"author"], @"The 'author' key should be mapped");
+    XCTAssertTrue([mapped containsObject:@"date"], @"The 'date' key should be mapped");
+    XCTAssertTrue([unmapped containsObject:@"category"], @"The 'category' key should not be mapped");
+    XCTAssertTrue([unmapped containsObject:@"tags"], @"The 'tags' key should not be mapped");
 }
 
 @end


### PR DESCRIPTION
@joshdholz To make it easier to see which json keys were mapped to properties I added a developer assistant. I also added equality methods to the base `JSONResource` class which supports copying objects. I've updated the tests with the new functionality. I've also changed the syntax to use modern literal syntax.

Instead of...

````objective-c
[dict objectForKey:key]
````

It now simply uses...

````objective-c
dict[key]
````

I believe it is more readable and less typing. Eventually the Developer Assistant could do more than simply tracking which keys are mapped or not. It could actually log out code in Objective-C or Swift which can be copied in place for mappings for keys. That would speed up my work quite a bit.

A very nice to have feature would be to also track values to detect dates (NSDate), integers (NSInteger) and floats (CGFloat) and also recommend a formatter. This could be helped by looking at the type for the potentially mapped property. I've not done reflection with Objective-C, though I expect reading in JSON for a given resource class could be the start of a process to generate the mapping recommendations.
