### PR TITLE
BUGFIX : Crash in the parser if resource descriptor not defined

### DIFF
--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -66,7 +66,10 @@
     
     NSMutableArray *mutableArray = @[].mutableCopy;
     for (NSDictionary *dictionary in array) {
-        [mutableArray addObject:[self parseResource:dictionary]];
+        NSObject <JSONAPIResource> *resource = [self parseResource:dictionary];
+        if(resource) {
+            [mutableArray addObject:[self parseResource:dictionary]];
+        }
     }
     
     return mutableArray;


### PR DESCRIPTION
When a ressource descriptor is not defined the `JSONAPIResourceParser` crash

See for more details : https://github.com/joshdholtz/jsonapi-ios/issues/19

Maybe add a logging message if an `RessourceDescriptor` is not found.