### PR TITLE
Add test and fix resolving included resources

### DIFF
--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -277,7 +277,7 @@
         // has many
         } else if ([value isKindOfClass:[NSArray class]]) {
             NSMutableArray *matched = [value mutableCopy];
-            [value enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            [value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                 NSObject <JSONAPIResource> *res = obj;
                 id v = includedValue[res.ID];
                 if (v != nil) {

--- a/Project/JSONAPITests/JSONAPITests.m
+++ b/Project/JSONAPITests/JSONAPITests.m
@@ -71,9 +71,14 @@
     JSONAPI *jsonAPI = [JSONAPI jsonAPIWithDictionary:json];
     
     PostResource *post = jsonAPI.resource;
+    CommentResource *firstComment = post.comments.firstObject;
+    
     XCTAssertNotNil(post.author, @"Post's author should not be nil");
     XCTAssertNotNil(post.comments, @"Post's comments should not be nil");
     XCTAssertEqual(post.comments.count, 2, @"Post should contain 2 comments");
+    XCTAssertEqualObjects(post.author.firstName, @"Dan", @"Post's author firstname should be 'Dan'");
+    XCTAssertEqualObjects(firstComment.text, @"First!", @"Post's first comment should be 'First!'");
+    XCTAssertEqualObjects(firstComment.author.firstName, @"Dan", @"Post's first comment author should be 'Dan'");
 }
 
 - (void)testIncludedCommentIsLinked {


### PR DESCRIPTION
Included resources were not resolved correctly. Even if included in the JSON object, the properties would not be mapped. This meant that the post's author in the test data would not get the correct `firstname` and `lastname`, neither would the comments be assigned correctly. I also added a test confirming the bug as well as the fix.

The issue was [`JSONAPIResourceParser`](https://github.com/joshdholtz/jsonapi-ios/blob/12b08a469a5ed3e27cd8b587211906ec3a495c75/Classes/JSONAPIResourceParser.m#L276) (and [few lines later](https://github.com/joshdholtz/jsonapi-ios/blob/12b08a469a5ed3e27cd8b587211906ec3a495c75/Classes/JSONAPIResourceParser.m#L283)) used the `Class` returned by `resourceType` as a key to access the included resources. However the key in the dictionary is in fact the `type` string returned by the descriptor.

Furthermore the value was set using `set:withDictionary:` ([1](https://github.com/joshdholtz/jsonapi-ios/blob/12b08a469a5ed3e27cd8b587211906ec3a495c75/Classes/JSONAPIResourceParser.m#L278), [2](https://github.com/joshdholtz/jsonapi-ios/blob/12b08a469a5ed3e27cd8b587211906ec3a495c75/Classes/JSONAPIResourceParser.m#L285)) which fails because the included resource is already parsed by that point, hence needs to be set as a value.