### PR TITLE
Fix #22 and allow `null` values in JSON when interoperating with Swift

### DIFF
--- a/Classes/JSONAPIErrorResource.h
+++ b/Classes/JSONAPIErrorResource.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Josh Holtz. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 /**
  *  Class respresentation of a JSON-API error structure.
  */

--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -205,7 +205,7 @@
             
         } else {
             id value = [attributes objectForKey:[property jsonName]];;
-            if (nil == value) {
+            if ((id)[NSNull null] == value) {
                 value = [dictionary objectForKey:[property jsonName]];
             }
             


### PR DESCRIPTION
Besides adding the missing import so the classes compile successfully after importing them to a project this also includes a fix for explicitly set `null` values in JSON. When the data is parsed this turns into `NSNull` which isn’t equal to nil. Setting the attribute to `NSNull` leads to a type mismatch so it needs to be included in the comparison so that scenario can be prevented.