### PR TITLE
Removing redundant double-parsing of resources

### DIFF
--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -68,7 +68,7 @@
     for (NSDictionary *dictionary in array) {
         NSObject <JSONAPIResource> *resource = [self parseResource:dictionary];
         if(resource) {
-            [mutableArray addObject:[self parseResource:dictionary]];
+            [mutableArray addObject:resource];
         }
     }
     


### PR DESCRIPTION
While taking a quick skim through the library to determine if it's something we'd like to use in a project (it is, great work btw) I ran into this strange looking part where resources appeared to be parsed twice.

Simply removing this doubling up causes tests to pass correctly so hopefully it's a cheap performance improvement.