### PR TITLE
Fixed linking problem

### DIFF
--- a/Classes/JSONAPI.h
+++ b/Classes/JSONAPI.h
@@ -40,6 +40,7 @@
 - (instancetype)initWithString:(NSString*)string;
 
 - (NSDictionary*)dictionary;
+- (NSDictionary*)allResources;
 
 - (id)includedResource:(id)ID withType:(NSString*)type;
 - (BOOL)hasErrors;

--- a/Classes/JSONAPI.m
+++ b/Classes/JSONAPI.m
@@ -146,13 +146,13 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
     // Link included with included
     for (NSDictionary *typeIncluded in _includedResources.allValues) {
         for (NSObject <JSONAPIResource> *resource in typeIncluded.allValues) {
-            [JSONAPIResourceParser link:resource withIncluded:self];
+            [JSONAPIResourceParser link:resource withAll:self];
         }
     }
     
     // Link data with included
     for (NSObject <JSONAPIResource> *resource in _resources) {
-        [JSONAPIResourceParser link:resource withIncluded:self];
+        [JSONAPIResourceParser link:resource withAll:self];
     }
     
     // Parse errors
@@ -203,6 +203,20 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
         [parsedResources addObject:[JSONAPIResourceParser dictionaryFor:linked]];
     }
     return parsedResources;
+}
+
+- (NSDictionary *)allResources {
+    NSMutableDictionary *all = self.includedResources.mutableCopy;
+    [self.resources enumerateObjectsUsingBlock:^(NSObject<JSONAPIResource> * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        NSString *type = [[obj.class descriptor] type];
+        NSMutableDictionary *allValue = [all[type] mutableCopy];
+        if(!allValue) {
+            allValue = @{}.mutableCopy;
+        }
+        allValue[obj.ID] = obj;
+        all[type] = allValue;
+    }];
+    return all;
 }
 
 @end

--- a/Classes/JSONAPIResourceParser.h
+++ b/Classes/JSONAPIResourceParser.h
@@ -70,7 +70,7 @@
  * @param resource model object
  * @param jsonAPI JSON-API message object
  */
-+ (void)link:(NSObject <JSONAPIResource>*)resource withIncluded:(JSONAPI*)jsonAPI;
++ (void)link:(NSObject <JSONAPIResource>*)resource withAll:(JSONAPI*)jsonAPI;
 
 /**
  * Get array of associated resource instances.

--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -278,10 +278,10 @@
 }
 
 
-+ (void)link:(NSObject <JSONAPIResource>*)resource withIncluded:(JSONAPI*)jsonAPI {
++ (void)link:(NSObject <JSONAPIResource>*)resource withAll:(JSONAPI*)jsonAPI {
     
-    NSDictionary *included = jsonAPI.includedResources;
-    if (nil == included) return;
+    NSDictionary *resources = jsonAPI.allResources;
+    if (nil == resources) return;
     
     JSONAPIResourceDescriptor *descriptor = [[resource class] descriptor];
     
@@ -307,9 +307,9 @@
             [value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                 if ([obj conformsToProtocol:@protocol(JSONAPIResource)]) {
                     NSObject <JSONAPIResource> *res = obj;
-                    id includedValue = included[[[res.class descriptor] type]];
-                    if (includedValue) {
-                        id v = includedValue[res.ID];
+                    id resourceValue = resources[[[res.class descriptor] type]];
+                    if (resourceValue) {
+                        id v = resourceValue[res.ID];
                         if (v != nil) {
                             matched[idx] = v;
                         }
@@ -322,9 +322,9 @@
         } else if (value != nil) {
             if ([value conformsToProtocol:@protocol(JSONAPIResource)]) {
                 id <JSONAPIResource> res = value;
-                id includedValue = included[[[res.class descriptor] type]];
-                if (includedValue) {
-                    id v = included[[[res.class descriptor] type]][res.ID];
+                id resourcesValue = resources[[[res.class descriptor] type]];
+                if (resourcesValue) {
+                    id v = resources[[[res.class descriptor] type]][res.ID];
                     if (v != nil) {
                         [resource setValue:v forKey:key];
                     }

--- a/JSONAPI.podspec
+++ b/JSONAPI.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '7.0'
   s.ios.deployment_target = '5.0'
-  s.tvos.deployment_target = '5.0'
+  s.tvos.deployment_target = '9.0'
   s.requires_arc = true
 
   s.public_header_files = 'Classes/*.h'

--- a/JSONAPI.podspec
+++ b/JSONAPI.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '7.0'
   s.ios.deployment_target = '5.0'
+  s.tvos.deployment_target = '5.0'
   s.requires_arc = true
 
   s.public_header_files = 'Classes/*.h'


### PR DESCRIPTION
- Linking with included only leaves incomplete objects if an object in “resources” has a reference to itself through an object in “included”
