### PR TITLE
Change JSONAPIResource protocol func name (Swift 3 compatibility)

### DIFF
--- a/Classes/JSONAPI.m
+++ b/Classes/JSONAPI.m
@@ -125,7 +125,7 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
                 JSONAPIResourceDescriptor *desc = [JSONAPIResourceDescriptor forLinkedType:data[@"type"]];
                 
                 NSMutableDictionary *typeDict = includedResources[desc.type] ?: @{}.mutableCopy;
-                typeDict[resource.ID] = resource;
+                typeDict[resource.iD] = resource;
                 
                 includedResources[desc.type] = typeDict;
             }
@@ -136,7 +136,7 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
             JSONAPIResourceDescriptor *desc = [JSONAPIResourceDescriptor forLinkedType:data[@"type"]];
             
             NSMutableDictionary *typeDict = includedResources[desc.type] ?: @{}.mutableCopy;
-            typeDict[resource.ID] = resource;
+            typeDict[resource.iD] = resource;
             
             includedResources[desc.type] = typeDict;
         }
@@ -190,7 +190,7 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
     for (NSObject <JSONAPIResource> *linked in relatedResources) {
         JSONAPIResourceDescriptor *desc = [[linked class] descriptor];
         NSMutableDictionary *typeDict = includedResources[desc.type] ?: @{}.mutableCopy;
-        typeDict[linked.ID] = resource;
+        typeDict[linked.iD] = resource;
         includedResources[desc.type] = typeDict;
     }
     return includedResources;

--- a/Classes/JSONAPIResource.h
+++ b/Classes/JSONAPIResource.h
@@ -115,7 +115,7 @@
  *
  * @return The record identifier for a resource instance.
  */
-- (id)ID;
+- (id)iD;
 
 /**
  * Set the API record identifier for a resource instance. Required for resources that come

--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -309,7 +309,7 @@
                     NSObject <JSONAPIResource> *res = obj;
                     id includedValue = included[[[res.class descriptor] type]];
                     if (includedValue) {
-                        id v = includedValue[res.ID];
+                        id v = includedValue[res.iD];
                         if (v != nil) {
                             matched[idx] = v;
                         }
@@ -324,7 +324,7 @@
                 id <JSONAPIResource> res = value;
                 id includedValue = included[[[res.class descriptor] type]];
                 if (includedValue) {
-                    id v = included[[[res.class descriptor] type]][res.ID];
+                    id v = included[[[res.class descriptor] type]][res.iD];
                     if (v != nil) {
                         [resource setValue:v forKey:key];
                     }
@@ -371,10 +371,10 @@
         [reference setValue:related forKey:@"related"];
     }
     
-    if (resource.ID) {
+    if (resource.iD) {
         NSDictionary *referenceObject = @{
                                           @"type" : descriptor.type,
-                                          @"id"   : resource.ID
+                                          @"id"   : resource.iD
                                           };
         if ([[owner valueForKey:key] isKindOfClass:[NSArray class]]) {
             reference = referenceObject.mutableCopy;


### PR DESCRIPTION
`-(id)ID;` will be genereted to `func id() -> Any?` in Swift 3.0 which conflicts with internal function

This commit changes `-(id)ID;` to `-(id)iD;`
