### PR TITLE
Updated RFC3339 format string

### DIFF
--- a/Classes/NSDateFormatter+JSONAPIDateFormatter.m
+++ b/Classes/NSDateFormatter+JSONAPIDateFormatter.m
@@ -16,7 +16,7 @@
     NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier: @"en_US_POSIX"];
     
     [dateFormatter setLocale: enUSPOSIXLocale];
-    [dateFormatter setDateFormat: @"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSS'Z'"];
+    [dateFormatter setDateFormat: @"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
     [dateFormatter setTimeZone: [NSTimeZone timeZoneForSecondsFromGMT: 0]];
   });
   


### PR DESCRIPTION
NSDateFormatter supports the new 'ZZZZZ' pattern, and that's Apple's recommended pattern for parsing RFC3339.
https://developer.apple.com/reference/foundation/nsdateformatter