### PR TITLE
Only update resource id if it is nil or not the same as value to be updated

### DIFF
--- a/Classes/JSONAPI.m
+++ b/Classes/JSONAPI.m
@@ -125,7 +125,7 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
                 JSONAPIResourceDescriptor *desc = [JSONAPIResourceDescriptor forLinkedType:data[@"type"]];
                 
                 NSMutableDictionary *typeDict = includedResources[desc.type] ?: @{}.mutableCopy;
-                typeDict[resource.ID] = resource;
+                typeDict[resource.iD] = resource;
                 
                 includedResources[desc.type] = typeDict;
             }
@@ -136,7 +136,7 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
             JSONAPIResourceDescriptor *desc = [JSONAPIResourceDescriptor forLinkedType:data[@"type"]];
             
             NSMutableDictionary *typeDict = includedResources[desc.type] ?: @{}.mutableCopy;
-            typeDict[resource.ID] = resource;
+            typeDict[resource.iD] = resource;
             
             includedResources[desc.type] = typeDict;
         }
@@ -190,7 +190,7 @@ static NSString *gMEDIA_TYPE = @"application/vnd.api+json";
     for (NSObject <JSONAPIResource> *linked in relatedResources) {
         JSONAPIResourceDescriptor *desc = [[linked class] descriptor];
         NSMutableDictionary *typeDict = includedResources[desc.type] ?: @{}.mutableCopy;
-        typeDict[linked.ID] = resource;
+        typeDict[linked.iD] = resource;
         includedResources[desc.type] = typeDict;
     }
     return includedResources;

--- a/Classes/JSONAPIResource.h
+++ b/Classes/JSONAPIResource.h
@@ -115,7 +115,7 @@
  *
  * @return The record identifier for a resource instance.
  */
-- (id)ID;
+- (id)iD;
 
 /**
  * Set the API record identifier for a resource instance. Required for resources that come

--- a/Classes/JSONAPIResourceFactory.h
+++ b/Classes/JSONAPIResourceFactory.h
@@ -1,0 +1,16 @@
+//
+//  JSONAPIResourceFactory.h
+//  JSONAPI
+//
+//  Created by V-Ken Chin on 11/4/18.
+//  Copyright © 2018 Josh Holtz. All rights reserved.
+//
+
+#ifndef JSONAPIResourceFactory_h
+#define JSONAPIResourceFactory_h
+
+#import "JSONAPIResource.h"
+@protocol JSONAPIResourceFactory <JSONAPIResource>
++ (id<JSONAPIResource>)resourceObjectFor:(NSDictionary *)dictionary;
+@end
+#endif /* JSONAPIResourceFactory_h */

--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -10,6 +10,7 @@
 #import "JSONAPI.h"
 #import "JSONAPIResourceDescriptor.h"
 #import "JSONAPIPropertyDescriptor.h"
+#import "JSONAPIResourceFactory.h"
 
 #pragma mark - JSONAPIResourceParser
 
@@ -56,7 +57,12 @@
     NSString *type = dictionary[@"type"] ?: @"";
     JSONAPIResourceDescriptor *descriptor = [JSONAPIResourceDescriptor forLinkedType:type];
     
-    NSObject <JSONAPIResource> *resource = [[[descriptor resourceClass] alloc] init];
+    NSObject <JSONAPIResource> *resource;
+    if ([[descriptor resourceClass] conformsToProtocol:@protocol(JSONAPIResourceFactory)]) {
+        resource = [[descriptor resourceClass] resourceObjectFor:dictionary];
+    } else {
+        resource = [[[descriptor resourceClass] alloc] init];
+    }
     [self set:resource withDictionary:dictionary];
     
     return resource;

--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -191,15 +191,17 @@
 	
     id ID = [dictionary objectForKey:@"id"];
     NSFormatter *format = [descriptor idFormatter];
-    if (format) {
-        id xformed;
-        if ([format getObjectValue:&xformed forString:ID errorDescription:&error]) {
-            [resource setValue:xformed forKey:[descriptor idProperty]];
+    if (resource.iD == nil || ![resource.iD isEqualToString:ID]) {
+        if (format) {
+            id xformed;
+            if ([format getObjectValue:&xformed forString:ID errorDescription:&error]) {
+                [resource setValue:xformed forKey:[descriptor idProperty]];
+            }
+        } else {
+            [resource setValue:ID forKey:[descriptor idProperty]];
         }
-    } else {
-        [resource setValue:ID forKey:[descriptor idProperty]];
     }
-    
+
     if (descriptor.selfLinkProperty) {
         NSString *selfLink = links[@"self"];
         [resource setValue:selfLink forKey:descriptor.selfLinkProperty];

--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -309,7 +309,7 @@
                     NSObject <JSONAPIResource> *res = obj;
                     id includedValue = included[[[res.class descriptor] type]];
                     if (includedValue) {
-                        id v = includedValue[res.ID];
+                        id v = includedValue[res.iD];
                         if (v != nil) {
                             matched[idx] = v;
                         }
@@ -324,7 +324,7 @@
                 id <JSONAPIResource> res = value;
                 id includedValue = included[[[res.class descriptor] type]];
                 if (includedValue) {
-                    id v = included[[[res.class descriptor] type]][res.ID];
+                    id v = included[[[res.class descriptor] type]][res.iD];
                     if (v != nil) {
                         [resource setValue:v forKey:key];
                     }
@@ -371,10 +371,10 @@
         [reference setValue:related forKey:@"related"];
     }
     
-    if (resource.ID) {
+    if (resource.iD) {
         NSDictionary *referenceObject = @{
                                           @"type" : descriptor.type,
-                                          @"id"   : resource.ID
+                                          @"id"   : resource.iD
                                           };
         if ([[owner valueForKey:key] isKindOfClass:[NSArray class]]) {
             reference = referenceObject.mutableCopy;

--- a/Classes/JSONAPIResourceParser.m
+++ b/Classes/JSONAPIResourceParser.m
@@ -118,7 +118,7 @@
                         }
                         
                         for (id valueElement in valueArray) {
-                            [dictionaryArray addObject:[self link:valueElement from:resource withKey:[property jsonName]]];
+                            [dictionaryArray addObject:[self link:valueElement from:resource withKey:key]];
                         }
                         
                         NSDictionary *dataDictionary = @{@"data" : dictionaryArray};
@@ -144,7 +144,7 @@
                     }
                     
                     NSObject <JSONAPIResource> *attribute = value;
-                    [linkage setValue:[self link:attribute from:resource withKey:[property jsonName]] forKey:[property jsonName]];
+                    [linkage setValue:[self link:attribute from:resource withKey:key] forKey:[property jsonName]];
                 } else {
                     format = [property formatter];
                     if (format) {

--- a/Project/JSONAPI.xcodeproj/project.pbxproj
+++ b/Project/JSONAPI.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		78A5C1D21C1E14D6008C8632 /* MediaResource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MediaResource.m; sourceTree = "<group>"; };
 		78A5C1D41C1E154C008C8632 /* WebPageResource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPageResource.h; sourceTree = "<group>"; };
 		78A5C1D51C1E154C008C8632 /* WebPageResource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebPageResource.m; sourceTree = "<group>"; };
+		86CE9D90207E168300D76280 /* JSONAPIResourceFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSONAPIResourceFactory.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -268,6 +269,7 @@
 				685481E91AE4161900D3A633 /* JSONAPIPropertyDescriptor.h */,
 				685481EA1AE4161900D3A633 /* JSONAPIPropertyDescriptor.m */,
 				033A6C5D18695CD2001CF9FA /* JSONAPIResource.h */,
+				86CE9D90207E168300D76280 /* JSONAPIResourceFactory.h */,
 				03FBD8DD1AB8DF8E00789DF3 /* JSONAPIErrorResource.h */,
 				03FBD8DE1AB8DF8E00789DF3 /* JSONAPIErrorResource.m */,
 				685481ED1AE419CB00D3A633 /* JSONAPIResourceDescriptor.h */,


### PR DESCRIPTION
This is to support using Realm as the persistence layer where primary keys (e.g. `id`) are not allowed to be updated after the object is inserted.